### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, try `pod install` again.
 7.  After a successful installation, CocoaPods generates a `.xcworkspace` file for your project. Open this workspace file in [Xcode](https://developer.apple.com/xcode/) to continue development.
 
 ```bash
-open <YourProjectName>.xcworkspace
+open < YourProjectName > .xcworkspace
 ```
 
 ### ✨ Using Ultralytics in Your Project

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, try `pod install` again.
 7.  After a successful installation, CocoaPods generates a `.xcworkspace` file for your project. Open this workspace file in [Xcode](https://developer.apple.com/xcode/) to continue development.
 
 ```bash
-open < YourProjectName > .xcworkspace
+open YourProjectName.xcworkspace
 ```
 
 ### ✨ Using Ultralytics in Your Project

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then, try `pod install` again.
 7.  After a successful installation, CocoaPods generates a `.xcworkspace` file for your project. Open this workspace file in [Xcode](https://developer.apple.com/xcode/) to continue development.
 
 ```bash
-open < YourProjectName > .xcworkspace
+open <YourProjectName>.xcworkspace
 ```
 
 ### ✨ Using Ultralytics in Your Project
@@ -71,14 +71,11 @@ Consider exploring the [Ultralytics documentation](https://docs.ultralytics.com/
 
 We welcome contributions from the community! Whether you're fixing bugs, adding new features, or improving documentation, your input is invaluable. Take a look at our [Contributing Guide](https://docs.ultralytics.com/help/contributing/) to get started. Also, we'd love to hear about your experience with Ultralytics products. Please consider filling out our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey). A huge 🙏 and thank you to all of our contributors!
 
-[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
+[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics-ios-podspecs/graphs/contributors)
 
 ## ©️ License
 
-Ultralytics offers two licensing options:
-
-- **AGPL-3.0 License**: An [OSI-approved](https://opensource.org/license/agpl-v3) open-source license ideal for students and enthusiasts. It promotes open collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/ultralytics/blob/main/LICENSE) file for details.
-- **Enterprise License**: Designed for commercial use, this license allows seamless integration of Ultralytics software and AI models into commercial products and services. If your application requires this license, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
+This repository includes an [AGPL-3.0 LICENSE](https://github.com/ultralytics/ultralytics-ios-podspecs/blob/main/LICENSE). The CocoaPods spec also declares the distributed `Ultralytics.xcframework` as commercial software, so review both the repository license and [Ultralytics Licensing](https://www.ultralytics.com/license) before distributing apps that include the pod.
 
 ## 📬 Contact Us
 


### PR DESCRIPTION
## Summary
- fixes the Xcode workspace open command in the CocoaPods installation flow
- retargets the contributors image link to this repository
- clarifies the license section against the local LICENSE and podspec metadata

## Validation
- git diff --check
- lychee README.md
- README checked against Ultralytics.podspec and release metadata

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves the `ultralytics-ios-podspecs` README by fixing an Xcode command, correcting the contributor link, and clarifying licensing for the iOS CocoaPods package.

### 📊 Key Changes
- Fixed the `open` command example for the generated Xcode workspace:
  - Changed from an invalid placeholder-style command to `open YourProjectName.xcworkspace` ✅
- Updated the contributors image link:
  - It now points to the correct contributors page for `ultralytics/ultralytics-ios-podspecs` instead of the main `ultralytics` repository 🔗
- Reworked the license section:
  - Replaced the generic Ultralytics dual-license explanation with repo-specific guidance
  - Clarified that this repository includes an [AGPL-3.0 license](https://github.com/ultralytics/ultralytics-ios-podspecs/blob/main/LICENSE)
  - Added a note that the distributed `Ultralytics.xcframework` is declared as commercial software in the podspec, with guidance to review [Ultralytics Licensing](https://www.ultralytics.com/license) before shipping apps 📄

### 🎯 Purpose & Impact
- Makes the setup instructions easier to follow, reducing confusion when opening the CocoaPods-generated workspace in Xcode 🚀
- Improves documentation accuracy by linking users to the correct repository contributors page 👥
- Helps developers better understand the licensing situation before integrating the pod into production or commercial apps ⚖️
- Reduces the risk of misunderstanding distribution rights around the packaged `Ultralytics.xcframework` 💡